### PR TITLE
Fixed PlacesNearby in a scope / Added ExploreResource

### DIFF
--- a/explore.go
+++ b/explore.go
@@ -213,3 +213,13 @@ func (scope *Scope) Explore(ctx context.Context, selector string, opts ExploreRe
 	// Call
 	return scope.session.explore(ctx, url, opts)
 }
+
+// ExploreResource searches in all elements of the given selector (lines, networks, etc.) linked to a resource inside a scope, returning a list of ptObjects
+// of the specific type.
+func (scope *Scope) ExploreResource(ctx context.Context, resId types.ID, selector string, opts ExploreRequest) (*ExploreResults, error) {
+	// Create the URL
+	url := scope.baseURL + "/" + resId.Type() + "s/" + string(resId) + "/" + selector
+
+	// Call
+	return scope.session.explore(ctx, url, opts)
+}

--- a/placesnearby.go
+++ b/placesnearby.go
@@ -86,7 +86,7 @@ func (s *Session) PlacesNearby(ctx context.Context, coords types.Coordinates, re
 // PlacesNearby searches for places near a point in a specific coverage.
 func (scope *Scope) PlacesNearby(ctx context.Context, coords types.Coordinates, req PlacesNearbyRequest) (*PlacesNearbyResults, error) {
 	// Build the url
-	url := scope.baseURL + "/" + string(coords.ID()) + "/" + placesNearbyEndpoint
+	url := scope.baseURL + "/coord/" + string(coords.ID()) + "/" + placesNearbyEndpoint
 
 	// Call & return
 	return scope.session.placesNearby(ctx, url, req)


### PR DESCRIPTION
Fixed PlacesNearby in a scope (missing "/coord/" URL node for coordinates)
Added ExploreResource to search for elements (lines, networks, ...) linked to a resource inside a scope (/coverage/{regionId}/{resourceType}/{resourceId}/{elementsName (lines/etc...)}