### PR TITLE
Fix "selector" mismatch in ExploreResource

### DIFF
--- a/explore.go
+++ b/explore.go
@@ -237,13 +237,13 @@ func (scope *Scope) ExploreResource(ctx context.Context, resID types.ID, selecto
 		return nil, errors.Wrapf(err, "ExploreResource: couldn't extract type from resource ID \"%s\"", resID)
 	}
 	// Get the selector equivalent
-	selector, ok := resourceTypeToSelector[resType]
+	typeSelector, ok := resourceTypeToSelector[resType]
 	if !ok {
-		return nil, errors.Errorf("ExploreResource: couldn't find the selector equivalent to the resource type identified (\"%s\")", resType)
+		return nil, errors.Errorf("ExploreResource: couldn't find the typeSelector equivalent to the resource type identified (\"%s\")", resType)
 	}
 
 	// Create the URL
-	url := scope.baseURL + "/" + selector + "/" + string(resID) + "/" + selector
+	url := scope.baseURL + "/" + typeSelector + "/" + string(resID) + "/" + selector
 
 	// Call
 	return scope.session.explore(ctx, url, opts)


### PR DESCRIPTION
There was an issue with "selector" overriding the function's parameter also named "selector"

For example, if you want "lines" in  ResID "stop_area:SIN:SA:OCE87757674", the request will be sent to URL : http://navitia.scity.coop/v1/coverage/default/stop_areas/stop_area:SIN:SA:OCE87757674/stop_areas?depth=0&disable_geojson=true

Instead of : http://navitia.scity.coop/v1/coverage/default/stop_areas/stop_area:SIN:SA:OCE87757674/lines?depth=0&disable_geojson=true