### PR TITLE
journey: Parse "durations" & "stop_date_times"

### DIFF
--- a/types/journeys.go
+++ b/types/journeys.go
@@ -44,6 +44,7 @@ var JourneyQualifications = []JourneyQualification{
 // A Journey holds information about a possible journey
 type Journey struct {
 	Duration  time.Duration
+	Durations map[string]time.Duration
 	Transfers uint
 
 	Departure time.Time

--- a/types/journeys_json.go
+++ b/types/journeys_json.go
@@ -21,6 +21,7 @@ func (j *Journey) UnmarshalJSON(b []byte) error {
 	// We define some of the value as pointers to the real values, allowing us to bypass copying in cases where we don't need to process the data
 	data := &struct {
 		Duration  int64 `json:"duration"`
+		Durations map[string]int64 `json:"durations"`
 		Transfers *uint `json:"nb_transfers"`
 
 		Departure string `json:"departure_date_time"`
@@ -58,6 +59,11 @@ func (j *Journey) UnmarshalJSON(b []byte) error {
 
 	// As the given duration is in second, let's multiply it by one second to have the correct value
 	j.Duration = time.Duration(data.Duration) * time.Second
+
+	j.Durations = make(map[string]time.Duration)
+	for k, v := range data.Durations {
+		j.Durations[k] = time.Duration(v) * time.Second
+	}
 
 	// For departure, requested and arrival, we use parseDateTime
 	j.Departure, err = parseDateTime(data.Departure)

--- a/types/section_json.go
+++ b/types/section_json.go
@@ -123,3 +123,20 @@ func (ptdt *PTDateTime) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
+
+func (st *StopTime) UnmarshalJSON(b []byte) error {
+	data := struct{
+		StopPoint StopPoint `json:"stop_point"`
+	}{}
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return errors.Wrap(err, "Error while unmarshalling stop time")
+	}
+	st.StopPoint = data.StopPoint
+
+	err = json.Unmarshal(b, &st.PTDateTime)
+	if err != nil {
+		return errors.Wrap(err, "Error while unmarshalling stop time")
+	}
+	return nil
+}


### PR DESCRIPTION
The fields `durations` and `stop_date_times` are now correctly parsed.